### PR TITLE
Changed `gofarmhash` source

### DIFF
--- a/util.go
+++ b/util.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"hash/fnv"
 
-	"code.google.com/p/gofarmhash"
+	"github.com/leemcloughlin/gofarmhash"
 )
 
 var hashera = fnv.New64()


### PR DESCRIPTION
Fixed #2 with the official successor package.