### PR TITLE
fixed imports and generalized test

### DIFF
--- a/cuckoofilter_test.go
+++ b/cuckoofilter_test.go
@@ -11,7 +11,7 @@ func TestInsertion(t *testing.T) {
 
 	cf := NewCuckooFilter(1000000)
 
-	fd, err := os.Open("/usr/share/dict/web2")
+	fd, err := os.Open("/usr/share/dict/words")
 	if err != nil {
 		fmt.Println(err.Error())
 		return
@@ -19,15 +19,18 @@ func TestInsertion(t *testing.T) {
 	scanner := bufio.NewScanner(fd)
 
 	var values [][]byte
+	var lineCount uint
 	for scanner.Scan() {
 		s := []byte(scanner.Text())
-		cf.InsertUnique(s)
+		if cf.InsertUnique(s) {
+			lineCount++
+		}
 		values = append(values, s)
 	}
 
 	count := cf.Count()
-	if count != 235081 {
-		t.Errorf("Expected count = 235081, instead count = %d", count)
+	if count != lineCount {
+		t.Errorf("Expected count = %d, instead count = %d", lineCount, count)
 	}
 
 	for _, v := range values {

--- a/util_test.go
+++ b/util_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"code.google.com/p/gofarmhash"
+	"github.com/leemcloughlin/gofarmhash"
 )
 
 func TestIndexAndFP(t *testing.T) {
@@ -23,7 +23,7 @@ func TestIndexAndFP(t *testing.T) {
 }
 
 func TestFarmhash(t *testing.T) {
-	fd, err := os.Open("/usr/share/dict/web2")
+	fd, err := os.Open("/usr/share/dict/words")
 	if err != nil {
 		fmt.Println(err.Error())
 		return


### PR DESCRIPTION
`/word` is more common between linux distros. It contains ~10k words, should be sufficient. Not sure if the number of words is consistent so I replaced the hard-coded value with a counter.