### PR TITLE
Algorithm improvements

### DIFF
--- a/cuckoofilter.go
+++ b/cuckoofilter.go
@@ -38,13 +38,20 @@ func (cf *CuckooFilter) Lookup(data []byte) bool {
 	return b1.getFingerprintIndex(fp) > -1 || b2.getFingerprintIndex(fp) > -1
 }
 
+func randi(i1, i2 uint) uint {
+	if rand.Intn(2) == 0 {
+		return i1
+	}
+	return i2
+}
+
 //Insert inserts data into the counter and returns true upon success
 func (cf *CuckooFilter) Insert(data []byte) bool {
 	i1, i2, fp := getIndicesAndFingerprint(data, uint(len(cf.buckets)))
 	if cf.insert(fp, i1) || cf.insert(fp, i2) {
 		return true
 	}
-	return cf.reinsert(fp, i2)
+	return cf.reinsert(fp, randi(i1, i2))
 }
 
 //InsertUnique inserts data into the counter if not exists and returns true upon success

--- a/util.go
+++ b/util.go
@@ -1,22 +1,16 @@
 package cuckoofilter
 
 import (
-	"encoding/binary"
-
 	"github.com/dgryski/go-metro"
 )
 
 func getAltIndex(fp byte, i uint, numBuckets uint) uint {
-	bytes := []byte{0, 0, 0, 0, 0, 0, 0, fp}
-	hash := binary.LittleEndian.Uint64(bytes)
-	return uint(uint64(i)^(hash*0x5bd1e995)) % numBuckets
+	hash := uint(metro.Hash64([]byte{fp}, 1337))
+	return (i ^ hash) % numBuckets
 }
 
 func getFingerprint(data []byte) byte {
-	fp := byte(metro.Hash64(data, 1337))
-	if fp == 0 {
-		fp += 7
-	}
+	fp := byte(metro.Hash64(data, 1335)%255 + 1)
 	return fp
 }
 

--- a/util.go
+++ b/util.go
@@ -2,12 +2,9 @@ package cuckoofilter
 
 import (
 	"encoding/binary"
-	"sync"
 
 	"github.com/dgryski/go-metro"
 )
-
-var hlock sync.Mutex
 
 func getAltIndex(fp byte, i uint, numBuckets uint) uint {
 	bytes := []byte{0, 0, 0, 0, 0, 0, 0, fp}
@@ -16,9 +13,6 @@ func getAltIndex(fp byte, i uint, numBuckets uint) uint {
 }
 
 func getFingerprint(data []byte) byte {
-	hlock.Lock()
-	defer hlock.Unlock()
-
 	fp := byte(metro.Hash64(data, 1337))
 	if fp == 0 {
 		fp += 7


### PR DESCRIPTION
I have a test that checks a space utilization:
```
	cf := cuckoofilter.NewCuckooFilter(cap)
	for i := uint(0); i < cap; i++ {
		ok := cf.Insert(randomBytes())
		if !ok {
			fmt.Printf("Error on %v/%v\n", i, cap)
		}
	}
```
With unmodified version of the cuckoofilter I have an error on 64073/1048576. It means that `reinsert` failed after 6% entries occupied.

With this PR I have no errors up to 96% space utilized. I believe that the problem is the similar hashing algorithms of fingerprint and i1. Your version is trying to reinsert `fp` to the same bucket and after `maxCuckooCount` it fails.

Also I removed the unnecessary lock in `getFingerprint` because it affected the use of multiple instances of the filter and didn't make the filter thread-safe. I think that lock should be in a filter object and lock/unlock should protect each public method.