### PR TITLE
Reduce repetition in naming; rename package

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -1,4 +1,4 @@
-package cuckoofilter
+package cuckoo
 
 type bucket [4]byte
 

--- a/cuckoofilter.go
+++ b/cuckoofilter.go
@@ -1,4 +1,4 @@
-package cuckoofilter
+package cuckoo
 
 import (
 	"fmt"
@@ -7,14 +7,16 @@ import (
 
 const maxCuckooCount = 500
 
-//CuckooFilter represents a probabalistic counter
-type CuckooFilter struct {
+// Filter is a probabalistic counter
+type Filter struct {
 	buckets []bucket
 	count   uint
 }
 
-//NewCuckooFilter returns a new cuckoofilter with a given capacity
-func NewCuckooFilter(capacity uint) *CuckooFilter {
+// NewFilter returns a new cuckoofilter with a given capacity.
+// A capacity of 1000000 is a normal default, which allocates
+// about ~1MB on 64-bit machines.
+func NewFilter(capacity uint) *Filter {
 	capacity = getNextPow2(uint64(capacity)) / bucketSize
 	if capacity == 0 {
 		capacity = 1
@@ -23,16 +25,11 @@ func NewCuckooFilter(capacity uint) *CuckooFilter {
 	for i := range buckets {
 		buckets[i] = [bucketSize]byte{}
 	}
-	return &CuckooFilter{buckets, 0}
+	return &Filter{buckets, 0}
 }
 
-//NewDefaultCuckooFilter returns a new cuckoofilter with the default capacity of 1000000
-func NewDefaultCuckooFilter() *CuckooFilter {
-	return NewCuckooFilter(1000000)
-}
-
-//Lookup returns true if data is in the counter
-func (cf *CuckooFilter) Lookup(data []byte) bool {
+// Lookup returns true if data is in the counter
+func (cf *Filter) Lookup(data []byte) bool {
 	i1, i2, fp := getIndicesAndFingerprint(data, uint(len(cf.buckets)))
 	b1, b2 := cf.buckets[i1], cf.buckets[i2]
 	return b1.getFingerprintIndex(fp) > -1 || b2.getFingerprintIndex(fp) > -1
@@ -45,8 +42,8 @@ func randi(i1, i2 uint) uint {
 	return i2
 }
 
-//Insert inserts data into the counter and returns true upon success
-func (cf *CuckooFilter) Insert(data []byte) bool {
+// Insert inserts data into the counter and returns true upon success
+func (cf *Filter) Insert(data []byte) bool {
 	i1, i2, fp := getIndicesAndFingerprint(data, uint(len(cf.buckets)))
 	if cf.insert(fp, i1) || cf.insert(fp, i2) {
 		return true
@@ -54,15 +51,15 @@ func (cf *CuckooFilter) Insert(data []byte) bool {
 	return cf.reinsert(fp, randi(i1, i2))
 }
 
-//InsertUnique inserts data into the counter if not exists and returns true upon success
-func (cf *CuckooFilter) InsertUnique(data []byte) bool {
+// InsertUnique inserts data into the counter if not exists and returns true upon success
+func (cf *Filter) InsertUnique(data []byte) bool {
 	if cf.Lookup(data) {
 		return false
 	}
 	return cf.Insert(data)
 }
 
-func (cf *CuckooFilter) insert(fp byte, i uint) bool {
+func (cf *Filter) insert(fp byte, i uint) bool {
 	if cf.buckets[i].insert(fp) {
 		cf.count++
 		return true
@@ -70,7 +67,7 @@ func (cf *CuckooFilter) insert(fp byte, i uint) bool {
 	return false
 }
 
-func (cf *CuckooFilter) reinsert(fp byte, i uint) bool {
+func (cf *Filter) reinsert(fp byte, i uint) bool {
 	for k := 0; k < maxCuckooCount; k++ {
 		j := rand.Intn(bucketSize)
 		oldfp := fp
@@ -86,13 +83,13 @@ func (cf *CuckooFilter) reinsert(fp byte, i uint) bool {
 	return false
 }
 
-//Delete data from counter if exists and return if deleted or not
-func (cf *CuckooFilter) Delete(data []byte) bool {
+// Delete data from counter if exists and return if deleted or not
+func (cf *Filter) Delete(data []byte) bool {
 	i1, i2, fp := getIndicesAndFingerprint(data, uint(len(cf.buckets)))
 	return cf.delete(fp, i1) || cf.delete(fp, i2)
 }
 
-func (cf *CuckooFilter) delete(fp byte, i uint) bool {
+func (cf *Filter) delete(fp byte, i uint) bool {
 	if cf.buckets[i].delete(fp) {
 		cf.count--
 		return true
@@ -100,13 +97,13 @@ func (cf *CuckooFilter) delete(fp byte, i uint) bool {
 	return false
 }
 
-//Count returns the number of items in the counter
-func (cf *CuckooFilter) Count() uint {
+// Count returns the number of items in the counter
+func (cf *Filter) Count() uint {
 	return cf.count
 }
 
 // Encode returns a byte slice representing a Cuckoofilter
-func (cf *CuckooFilter) Encode() []byte {
+func (cf *Filter) Encode() []byte {
 	bytes := make([]byte, len(cf.buckets)*bucketSize)
 	for i, b := range cf.buckets {
 		for j, f := range b {
@@ -118,7 +115,7 @@ func (cf *CuckooFilter) Encode() []byte {
 }
 
 // Decode returns a Cuckoofilter from a byte slice
-func Decode(bytes []byte) (*CuckooFilter, error) {
+func Decode(bytes []byte) (*Filter, error) {
 	var count uint
 	if len(bytes)%4 != 0 {
 		return nil, fmt.Errorf("expected bytes to be multiuple of 4, got %d", len(bytes))
@@ -133,7 +130,7 @@ func Decode(bytes []byte) (*CuckooFilter, error) {
 			}
 		}
 	}
-	return &CuckooFilter{
+	return &Filter{
 		buckets: buckets,
 		count:   count,
 	}, nil

--- a/cuckoofilter_test.go
+++ b/cuckoofilter_test.go
@@ -1,4 +1,4 @@
-package cuckoofilter
+package cuckoo
 
 import (
 	"bufio"
@@ -9,7 +9,7 @@ import (
 )
 
 func TestInsertion(t *testing.T) {
-	cf := NewCuckooFilter(1000000)
+	cf := NewFilter(1000000)
 	fd, err := os.Open("/usr/share/dict/words")
 	if err != nil {
 		fmt.Println(err.Error())
@@ -43,7 +43,7 @@ func TestInsertion(t *testing.T) {
 }
 
 func TestEncodeDecode(t *testing.T) {
-	cf := NewCuckooFilter(8)
+	cf := NewFilter(8)
 	cf.buckets = []bucket{
 		[4]byte{1, 2, 3, 4},
 		[4]byte{5, 6, 7, 8},

--- a/doc.go
+++ b/doc.go
@@ -19,7 +19,7 @@ SOFTWARE.
 */
 
 /*
-Package cuckoofilter provides a Cuckoo Filter, a Bloom filter replacement for approximated set-membership queries.
+Package cuckoo provides a Cuckoo Filter, a Bloom filter replacement for approximated set-membership queries.
 
 While Bloom filters are well-known space-efficient data structures to serve queries like "if item x is in a set?", they do not support deletion. Their variances to enable deletion (like counting Bloom filters) usually require much more space.
 
@@ -32,4 +32,4 @@ For details about the algorithm and citations please use this article:
 
 Note:
 This implementation uses a a static bucket size of 4 fingerprints and a fingerprint size of 1 byte based on my understanding of an optimal bucket/fingerprint/size ratio from the aforementioned paper.*/
-package cuckoofilter
+package cuckoo

--- a/util.go
+++ b/util.go
@@ -1,7 +1,7 @@
-package cuckoofilter
+package cuckoo
 
 import (
-	"github.com/dgryski/go-metro"
+	metro "github.com/dgryski/go-metro"
 )
 
 func getAltIndex(fp byte, i uint, numBuckets uint) uint {

--- a/util_test.go
+++ b/util_test.go
@@ -1,12 +1,10 @@
-package cuckoofilter
+package cuckoo
 
 import (
 	"bufio"
 	"fmt"
 	"os"
 	"testing"
-
-	"github.com/leemcloughlin/gofarmhash"
 )
 
 func TestIndexAndFP(t *testing.T) {


### PR DESCRIPTION
This is a breaking change, of course, but it's very simple and makes the package a little more elegant IMO. :)

- Renamed package to `cuckoo`
- Renamed `NewCuckooFilter` to `NewFilter`
- Removed `NewDefaultCuckooFilter` as it is not very useful (updated godoc on `NewFilter` to suggest 1000000 as a normal default capacity).

Closes #19