### PR TITLE
remove unnecessary initialization

### DIFF
--- a/cuckoofilter.go
+++ b/cuckoofilter.go
@@ -24,9 +24,6 @@ func NewFilter(capacity uint) *Filter {
 		capacity = 1
 	}
 	buckets := make([]bucket, capacity)
-	for i := range buckets {
-		buckets[i] = [bucketSize]byte{}
-	}
 	return &Filter{
 		buckets:   buckets,
 		count:     0,


### PR DESCRIPTION
When creating a slice of arrays its elements do not have to be initialized. In this case that means the range over the buckets can be removed.